### PR TITLE
Datetimeoffset throws error when value 0001-01-01

### DIFF
--- a/src/UblSharp/UnqualifiedDataTypes/DateType.cs
+++ b/src/UblSharp/UnqualifiedDataTypes/DateType.cs
@@ -17,7 +17,15 @@ namespace UblSharp.UnqualifiedDataTypes
             }
             set
             {
-                Value = XmlConvert.ToDateTimeOffset(value);
+                try
+                {
+                    Value = XmlConvert.ToDateTimeOffset(value);
+
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    Value = DateTimeOffset.MinValue;
+                }
             }
         }
 


### PR DESCRIPTION
Hello,
I have recently found a bug which cause a ArgumentOutOfRangeException when the parsed string has 0001-01-01 value. 

Related SO link;
https://stackoverflow.com/questions/13799214/the-utc-time-represented-when-the-offset-is-applied-must-be-between-year-0-and-1